### PR TITLE
wip: started the exchange API documentation

### DIFF
--- a/skycoin/exchange-api.md
+++ b/skycoin/exchange-api.md
@@ -148,7 +148,107 @@ type MarketRecord struct {
 
 ## REST API
 
-briancaine note: as above... where I'd document the rest API, including samples
+Tradebot's REST API is based on [JSON-RPC 2.0](http://www.jsonrpc.org/specification).
+
+### Types
+
+The REST API accepts/returns simple JSON types, like strings and numbers, as well as complex structures.
+
+Two reoccurring structures the API uses are:
+
+* Order:
+```json
+{
+  "orderid": 1,
+  "type": "Buy",
+  "market": "LTC/BTC",
+  "amount": 100.123,
+  "price": 0.0001,
+  "submitted_at": 1501200244000,
+  "fee": 0.001,
+  "completed_amount": 99.9,
+  "status": "Cancelled",
+  "completed_at": 1501200244000,
+  "accepted_at": 1501200244000
+}
+```
+* Orderbook_record:
+```json
+{
+  "timestamp": 1516255342,
+  "symbol": "LTC/BTC",
+  "asks": [{"price": 12345.67, "volume": 12.345},{"price": 23456.78, "volume": 23.456}],
+  "bids": [{"price": 34567.89, "volume": 34.567},{"price": 14567.89, "volume": 543.21}]
+}
+```
+
+### Methods
+
+#### `buy`
+
+Parameters: `{"symbol": string, "price": number, "amount", number}`
+
+Returns: `number` (order ID)
+
+#### `sell`
+
+Parameters: `{"symbol": string, "price": number, "amount", number}`
+
+Returns: `number` (order ID)
+
+#### `cancel_trade`
+
+Parameters: `{"orderid": number}` (order ID)
+
+Returns: `Order`
+
+#### `cancel_market`
+
+Parameters: `{"symbol": string}`
+
+Returns: `array of Order`
+
+#### `cancel_all`
+
+Parameters: `{}` or `null`
+
+Returns: `array of Order`
+
+#### `balance`
+
+Parameters: `{"currency": string}`
+
+Returns: `string`
+
+#### `order_info`
+
+Parameters: `{"orderid": number}` (order ID, obviously enough)
+
+Returns: `Order`
+
+#### `order_status`
+
+Parameters: `{"orderid": number}` (order ID again)
+
+Returns: `string`
+
+#### `completed`
+
+Parameters: `{}` or `null`
+
+Returns: `array of number` (array of order IDs)
+
+#### `executed`
+
+Parameters: `{}` or `null`
+
+Returns: `array of number` (array of order IDs)
+
+#### `orderbook`
+
+Parameters: `{"symbol": string}`
+
+Returns: `Orderbook_record`
 
 ## CLI
 

--- a/skycoin/exchange-api.md
+++ b/skycoin/exchange-api.md
@@ -91,6 +91,8 @@ type Orderbooks interface {
 
 #### Order
 
+[Source](https://github.com/skycoin/exchange-api/blob/0b17f1aaf8967d3423495918ab350e290eaeafa8/exchange/exchange.go#L11)
+
 ```golang
 type Order struct {
 	Type      string
@@ -110,6 +112,8 @@ type Order struct {
 ```
 
 #### Order types
+
+[Source](https://github.com/skycoin/exchange-api/blob/0b17f1aaf8967d3423495918ab350e290eaeafa8/exchange/exchange.go#L5)
 
 ```golang
 const (

--- a/skycoin/exchange-api.md
+++ b/skycoin/exchange-api.md
@@ -1,0 +1,47 @@
+# tradebot
+
+Tradebot is a Go abstraction of cryptocoin trading exchanges. It abstract these four operations:
+* placing a bid/ask order
+* tracking the status of an existing order
+* withdrawing bitcoin from the exchange
+* depositing bitcoin to the exchange
+
+Tradebot provides an internal Go API, a REST API, and a command line interface.
+
+Currently tradebot supports the `cryptopia` and `c2cx` exchanges. Additional exchanges can be implemented in Go.
+
+## Terminology
+
+briancaine note:
+
+  so, I added this section in case we might want to clarify any terminology.
+
+  I'm guessing we're using standard terminology but
+
+  maybe we might need to (for technical reasons) clarify what we mean
+
+  (ie, like, does a transaction include fees or not? do we want to clarify that somewhere?)
+
+  if not, then we can just delete this section
+
+## Go
+
+### Library API
+
+briancaine note:
+
+  here's where we document tradebot if you wanted to link it into another program as a library. straightforward enough
+
+### Exchange API
+
+briancaine note:
+
+  here's where we document implementing a new exchange for tradebot
+
+## REST API
+
+briancaine note: as above... where I'd document the rest API, including samples
+
+## CLI
+
+briancaine note: self explanatory, I'd think

--- a/skycoin/exchange-api.md
+++ b/skycoin/exchange-api.md
@@ -10,6 +10,8 @@ Tradebot provides an internal Go API, a REST API, and a command line interface.
 
 Currently tradebot supports the `cryptopia` and `c2cx` exchanges. Additional exchanges can be implemented in Go.
 
+You can view [tradebot's source code](https://github.com/skycoin/exchange-api) via github.
+
 ## Terminology
 
 briancaine note:

--- a/skycoin/exchange-api.md
+++ b/skycoin/exchange-api.md
@@ -252,4 +252,25 @@ Returns: `Orderbook_record`
 
 ## CLI
 
-briancaine note: self explanatory, I'd think
+Tradebot provides a command line interface to the REST API.
+
+A CLI call takes the form: `cli <exchange> <command> [subcommand] [params...]`
+
+Available CLI commands:
+* `order`
+  * `info <orderid>`
+  * `status <orderid>`
+* `cancel`
+  * `all`
+  * `market <symbol>`
+  * `trade <orderid>`
+* `buy <symbol> <price> <amount>`
+* `sell <symbol> <price> <amount>`
+* `orderbook <symbol>`
+* `executed`
+  * `market <symbol>`
+  * `all`
+* `completed`
+  * `market <symbol>`
+  * `all`
+* `balance <currency>`


### PR DESCRIPTION
Work In Progress

Assumptions:

So I assume I'm documenting the existing exchange API,
github.com/gz-c/tradebot .

tradebot seems pretty complete, so I assume we'll be focusing on
documenting the outward facing portions. (ie writing go code using this
as a library to generically use exchanges, or implementing a new
exchange)